### PR TITLE
fix: Celigo record wrapper parsing; remove mock DB seeding

### DIFF
--- a/src/lib/celigo-mapper.ts
+++ b/src/lib/celigo-mapper.ts
@@ -108,7 +108,7 @@ export function celigoRecordToProduct(record: CeligoRecord): ProductRecord | nul
 }
 
 /**
- * Parse Celigo export payload: { page_of_records: [ record, ... ] }.
+ * Parse Celigo export payload: { page_of_records: [ record | { record }, ... ] }.
  * Returns array of ProductRecord; skips records that can't be mapped.
  */
 export function parseCeligoPayload(body: unknown): ProductRecord[] {
@@ -118,9 +118,13 @@ export function parseCeligoPayload(body: unknown): ProductRecord[] {
   if (!Array.isArray(records)) return [];
   const products: ProductRecord[] = [];
   for (const item of records) {
-    const record = item && typeof item === "object" ? (item as CeligoRecord) : null;
-    if (!record) continue;
-    const product = celigoRecordToProduct(record);
+    const container = item && typeof item === "object" ? (item as Record<string, unknown>) : null;
+    const rawRecord =
+      container && container.record && typeof container.record === "object"
+        ? (container.record as CeligoRecord)
+        : (container as CeligoRecord | null);
+    if (!rawRecord) continue;
+    const product = celigoRecordToProduct(rawRecord);
     if (product) products.push(product);
   }
   return products;

--- a/src/lib/products-repository.ts
+++ b/src/lib/products-repository.ts
@@ -1,5 +1,5 @@
 import db from "@/lib/db";
-import { mockProducts, ProductRecord } from "@/lib/mock-products";
+import { ProductRecord } from "@/lib/mock-products";
 
 type ProductRow = {
   id: string;
@@ -48,18 +48,6 @@ const findByBarcodeStmt = db.prepare(
 const listRecentStmt = db.prepare(
   "SELECT * FROM products ORDER BY updated_at DESC, name ASC LIMIT ?",
 );
-
-const seedIfEmpty = db.transaction(() => {
-  const countRow = countStmt.get() as { total: number } | undefined;
-  if ((countRow?.total ?? 0) > 0) {
-    return;
-  }
-  for (const product of mockProducts) {
-    upsertStmt.run(product);
-  }
-});
-
-seedIfEmpty();
 
 export function findProductByBarcode(barcode: string): ProductRecord | null {
   const row = findByBarcodeStmt.get(barcode) as ProductRow | undefined;


### PR DESCRIPTION
- Accept page_of_records entries as plain records or { record } wrappers
- Stop auto-seeding products from mock data when the database is empty

Made-with: Cursor