### PR TITLE
fix: rename middleware.ts to proxy.ts for Next.js 16 compatibility

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,10 @@
 import NextAuth from "next-auth";
 import { authConfig } from "./auth.config";
 
-// Use the edge-safe config only — no DB imports in this file.
-export const { auth: middleware } = NextAuth(authConfig);
+// Next.js 16+ uses proxy.ts instead of middleware.ts
+const { auth } = NextAuth(authConfig);
+
+export default auth;
 
 export const config = {
   matcher: ["/admin/:path*", "/api/admin/:path*"],


### PR DESCRIPTION
## Summary

Fixes a build error on Next.js 16 where `middleware.ts` is deprecated in favour of `proxy.ts`.

**Error on VM:**
```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
Error: The file "./src/middleware.ts" must export a function, either as a default export or as a named "middleware" export.
```

**Changes:**
- Renamed `src/middleware.ts` → `src/proxy.ts`
- Changed from named export (`export const { auth: middleware }`) to default export (`export default auth`) as required by Next.js 16

Route protection behaviour is unchanged — `/admin/*` still redirects to `/admin/login` and `/api/admin/*` still returns `401`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)